### PR TITLE
Dockerfile: fixes docker load on windows. App.js: loads homepage without node insertbefore issues on L27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,12 +36,14 @@ RUN npm -v
 # export keys to env file
 COPY .env ./
 
-COPY startup.sh ./
-RUN ./startup.sh
+ADD "https://www.random.org/cgi-bin/randbyte?nbytes=10&format=h" skipcache
+RUN if [ -f "package-lock.json" ]; then rm package-lock.json; fi;
+RUN if [ -d "node_modules" ]; then rm -rf node_modules; fi;
+RUN if [ -d "~/.npm/_cacache" ]; then rm -rf ~/.npm/_cacache; fi;
 
 # install packages
 COPY package.json ./
-RUN npm cache verify && npm i
+RUN npm i
 
 # add app
 COPY public ./public

--- a/src/App.js
+++ b/src/App.js
@@ -24,9 +24,7 @@ function App() {
       scriptTawk.charset = "UTF-8";
       scriptTawk.setAttribute("crossorigin", "*");
       fragmentTawk.appendChild(scriptTawk);
-      const firstScript = document.querySelector("script");
-
-      document.head.insertBefore(fragmentTawk, firstScript);
+      document.querySelector("script").before(fragmentTawk);
     })();
 
     //import cookiebot script

--- a/startup.sh
+++ b/startup.sh
@@ -1,7 +1,3 @@
-# remove package-lock.json if present;
-if [ -f "package-lock.json" ]; then rm package-lock.json; fi;
-if [ -d "node_modules" ]; then rm -rf node_modules; fi;
-
 # export keys to env file
 echo "REACT_APP_GOOGLE_MAPS_API_KEY=$GOOGLE_MAPS_API_KEY" > .env;
 echo "REACT_APP_FIREBASE_API_KEY=$FIREBASE_API_KEY" >> .env;


### PR DESCRIPTION
No need to execute `startup.sh`; 
It is already executed in netlify build;
In docker its substitute is the `.env` file which is supposed to be already loaded;
fixes #133

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcov19/mycovidconnect/135)
<!-- Reviewable:end -->
